### PR TITLE
Prepend the root path when using relative urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ USAGE:
    hlstail [options...] <playlist>
 
 VERSION:
-   1.0.11
+   1.0.12
 
 COMMANDS:
    help, h  Shows a list of commands or help for one command

--- a/cmd/hlstail/main.go
+++ b/cmd/hlstail/main.go
@@ -18,7 +18,7 @@ import (
 func main() {
 	app := cli.NewApp()
 	app.Name = "hlstail"
-	app.Version = "1.0.11"
+	app.Version = "1.0.12"
 
 	app.Usage = "Query an HLS playlist and then tail the new segments of a selected variant"
 

--- a/pkg/hls/master.go
+++ b/pkg/hls/master.go
@@ -152,6 +152,8 @@ func parseVariants(rootURL *url.URL, rawData string) []*Variant {
 			// Here we want to fill in the blanks if the provided url is relative.
 			if u.Host == "" {
 				u.Host = rootURL.Host
+				rootPath := strings.Split(rootURL.Path, "/")
+				u.Path = fmt.Sprintf("%s/%s", strings.Join(rootPath[:len(rootPath)-1], "/"), u.Path)
 			}
 
 			if u.Scheme == "" {


### PR DESCRIPTION
Fixes a minor issue were the top components of the _path_ component of relative paths.

For example given a master playlist of:
`https://example.com/some/relative/path/master.m3u8`

With relative variant playlist `variant.m3u8`, the resulting URL would be:

`https://example.com/variant.m3u8`

instead of:

`https://example.com/some/relative/path/variant.m3u8`

This PR fixes that.